### PR TITLE
Fix matlab command used to check matlab path

### DIFF
--- a/tvb/core/utils.py
+++ b/tvb/core/utils.py
@@ -390,7 +390,7 @@ def matlab_cmd(matlab_path, script_name, log_file):
         os.environ['PATH'] = os.environ.get('PATH', '') + os.pathsep + folder_path
     if MATLAB in exe_name:
         base = exe_name + ' '
-        opts = ' -nodesktop -nojvm -nosplash -logfile %s -r "%s;"' % (log_file, script_name)
+        opts = ' -nodesktop -nojvm -nosplash -logfile %s -r "run %s "' % (log_file, script_name)
         if os.name == 'nt':
             opts = '-minimize ' + opts
         command = base + opts


### PR DESCRIPTION
**OSes**: Linux 64-bit Manjaro 18 / OpenSUSE 42.3
**bash**: 4.4
**TVB**: 1.5.4-8430 and `master` branch

The check to validate the Matlab/Octave path was failing:
![invalidmatlabpath](https://user-images.githubusercontent.com/1563810/49710261-0edc4780-fc84-11e8-8b60-d39c8c924717.png)
 
The console output:
![invalidmatlabpath_matlab](https://user-images.githubusercontent.com/1563810/49710340-7d210a00-fc84-11e8-92e3-d4d8b020bf8d.png)


This PR fixes the command used to run the check.


![validmatlabpath](https://user-images.githubusercontent.com/1563810/49710373-b22d5c80-fc84-11e8-860d-be9eff450854.png)

![validmatlabpath_matlab](https://user-images.githubusercontent.com/1563810/49710371-b22d5c80-fc84-11e8-9034-54d73f8661df.png)
